### PR TITLE
Add redirect from index.html and switch bootstrap fonts to https

### DIFF
--- a/finetuneas.html
+++ b/finetuneas.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
           integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
-    <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; url='finetuneas.html'" />


### PR DESCRIPTION
Thank you for creating this awesome interface! 

It would be great if this interface could be used directly from github pages without cloning the repo. This PR adds an `index.html` that redirects to `finetuneas.html` and ensures all sub-resources are fetched over `https`. Merging this PR and setting the source branch of Github pages to `master` in the repo settings would enable any annotator to use `finetuneas` without having to clone or download anything. 